### PR TITLE
Add endpoint update petition actions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionkit_connector (0.4.3)
+    actionkit_connector (0.4.4)
       httparty (~> 0.13)
 
 GEM
@@ -53,4 +53,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/lib/actionkit_connector/rest/api.rb
+++ b/lib/actionkit_connector/rest/api.rb
@@ -11,6 +11,7 @@ require 'actionkit_connector/rest/language'
 require 'actionkit_connector/rest/tag'
 require 'actionkit_connector/rest/user'
 require 'actionkit_connector/rest/recurring_payment_cancellation'
+require 'actionkit_connector/rest/petition_action'
 
 module ActionKitConnector
   module REST
@@ -29,6 +30,7 @@ module ActionKitConnector
       include ActionKitConnector::REST::Tag
       include ActionKitConnector::REST::User
       include ActionKitConnector::REST::RecurringPaymentCancellation
+      include ActionKitConnector::REST::PetitionAction
     end
   end
 end

--- a/lib/actionkit_connector/rest/petition_action.rb
+++ b/lib/actionkit_connector/rest/petition_action.rb
@@ -1,0 +1,9 @@
+module ActionKitConnector
+  module REST
+    module PetitionAction
+      def update_petition_action(id, data)
+        self.class.put("/petitionaction/#{id}/", prep_options(data))
+      end
+    end
+  end
+end

--- a/spec/fixtures/cassettes/update_petition_action.yml
+++ b/spec/fixtures/cassettes/update_petition_action.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<USERNAME>:<PASSWORD>@act.sumofus.org/rest/v1/petitionaction/61821024/
+    body:
+      encoding: UTF-8
+      string: '{"page":"/rest/v1/petitionpage/16483/","name":"Help me"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 204
+      message: NO CONTENT
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 13 Oct 2016 15:12:01 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - sid=t7eq0qm608gx2ggfu28uftb35r4c4ck7; expires=Thu, 13-Oct-2016 23:12:01 GMT;
+        httponly; Max-Age=28800; Path=/
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      X-Machine-Id:
+      - ip-10-50-1-128
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 13 Oct 2016 15:12:08 GMT
+recorded_with: VCR 3.0.1

--- a/spec/lib/rest/petition_action_spec.rb
+++ b/spec/lib/rest/petition_action_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe ActionKitConnector::REST::PetitionAction do
+  describe "#update_petition_action" do
+    it "responds successfully" do
+      VCR.use_cassette "update_petition_action" do
+        params = {
+          page: "/rest/v1/petitionpage/16483/",
+          name: "Help me"
+        }
+        response = client.update_petition_action("61821024", params)
+        expect(response.success?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR will allow us to update actions on AK. Its needed for the survey plugin tool, since we want to update the action every time a user replies a survey question.
