### PR TITLE
Add batch upload methods

### DIFF
--- a/lib/actionkit_connector/connector.rb
+++ b/lib/actionkit_connector/connector.rb
@@ -15,6 +15,20 @@ module ActionKitConnector
       self.class.post('/donationpush/', prep_options(data))
     end
 
+    def batch_upsert_users(page_name, file, other_params)
+      params = {
+        basic_auth: self.auth,
+        body: {
+          upload: file,
+          page: page_name,
+        }.merge(other_params)
+      }
+      self.class.post('/upload/', params)
+    end
+
+    def get_upload(id)
+      self.class.get("/upload/#{id}/", { basic_auth: self.auth })
+    end
 
     # Initializes a connector to the ActionKit API.
     # A new connection is created on each call, so there

--- a/lib/actionkit_connector/connector.rb
+++ b/lib/actionkit_connector/connector.rb
@@ -15,17 +15,36 @@ module ActionKitConnector
       self.class.post('/donationpush/', prep_options(data))
     end
 
-    def batch_upsert_users(page_name, file, other_params)
+    # Iniatiates a batch upload of user information through and import page
+    #
+    # @param [String] import_page_id The id of the import page you wish to load data through. 
+    # @param [File] file A Ruby file object (or equivalent IOstream) containing the CSV to upload
+    # @param [Hash] other_params Other options you wish to pass to the upload
+    # @param [Boolean] danger_check Should a safety check be performed to make sure the 
+    #   page doesn't change the users language or subscriptions
+
+    def batch_upsert_users(import_page_id, file, other_params, danger_check = true)
+      page = import_page(import_page_id)
+      if danger_check && page.slice('language', 'subscribe', 'unsubscribe', 'unsubscribe_all').values.any? 
+        raise "Aborting because import page is set to change users' language or subscriptions. Re-run with danger_check = false if you are sure you want to do this."
+      end
+
       params = {
         basic_auth: self.auth,
         body: {
           upload: file,
-          page: page_name,
+          page: page['title'],
         }.merge(other_params)
       }
-      self.class.post('/upload/', params)
+
+      response = self.class.post('/upload/', params)
+      raise BatchUpsertUsersError, response.body unless response.code == 201
+      response.headers['location'].split('/').last.to_i # Get the ID of the upload
     end
 
+    # Returns status information about an upload in progress
+    #
+    # @param [Int] id The ID of the upload.
     def get_upload(id)
       self.class.get("/upload/#{id}/", { basic_auth: self.auth })
     end
@@ -108,6 +127,15 @@ module ActionKitConnector
          }.to_json
       }
       self.class.post(target, options)
+    end
+
+    # Returns the information for a single ImportPage.
+    #
+    # @param [Int] id The ID of the page to return.
+    def import_page(id)
+      target = "#{self.base_url}/importpage/#{id}/"
+      response = self.class.get(target, {basic_auth: self.auth})
+      JSON.parse(response.body)
     end
 
     # Create a donation page in your ActionKit instance.
@@ -212,5 +240,7 @@ module ActionKitConnector
       { basic_auth: auth, body: data.to_json }
     end
   end
+
+  class BatchUpsertUsersError < StandardError; end
 end
 


### PR DESCRIPTION
This adds methods to use the [Uploads REST API](https://roboticdogs.actionkit.com/docs/manual/api/rest/uploads.html) to initiate an upload using a CSV, and check on the status of the upload using the returned upload ID.